### PR TITLE
Add pickup person name to fulfillment

### DIFF
--- a/packages/beckn-vendure-plugin/e2e/fixtures/beckn-requests/1-1-0/update-address.json
+++ b/packages/beckn-vendure-plugin/e2e/fixtures/beckn-requests/1-1-0/update-address.json
@@ -46,7 +46,7 @@
                                     "area_code": "560025"
                                 },
                                 "contact": {
-                                    "name": "Motiur Rehman",
+                                    "name": "Waheeda Rehman",
                                     "phone": "919845998459"
                                 }
                             }

--- a/packages/beckn-vendure-plugin/e2e/fixtures/beckn-responses/1-1-0/on-status-service.json
+++ b/packages/beckn-vendure-plugin/e2e/fixtures/beckn-responses/1-1-0/on-status-service.json
@@ -116,6 +116,7 @@
                                     "area_code": "560300"
                                 },
                                 "contact": {
+                                    "name": "Motiur Rehman",
                                     "phone": "919122343355",
                                     "email": "nc.rehman@gmail.com"
                                 }

--- a/packages/beckn-vendure-plugin/e2e/fixtures/beckn-responses/1-1-0/on-status.json
+++ b/packages/beckn-vendure-plugin/e2e/fixtures/beckn-responses/1-1-0/on-status.json
@@ -115,6 +115,7 @@
                                     "area_code": "560300"
                                 },
                                 "contact": {
+                                    "name": "Motiur Rehman",
                                     "phone": "919122343355",
                                     "email": "nc.rehman@gmail.com"
                                 }

--- a/packages/beckn-vendure-plugin/e2e/fixtures/beckn-responses/1-1-0/on-update-address.json
+++ b/packages/beckn-vendure-plugin/e2e/fixtures/beckn-responses/1-1-0/on-update-address.json
@@ -115,6 +115,7 @@
                                     "area_code": "560025"
                                 },
                                 "contact": {
+                                    "name": "Waheeda Rehman",
                                     "phone": "919845998459",
                                     "email": "nc.rehman@gmail.com"
                                 }

--- a/packages/beckn-vendure-plugin/e2e/fixtures/test-configurations/1-1-0.json
+++ b/packages/beckn-vendure-plugin/e2e/fixtures/test-configurations/1-1-0.json
@@ -170,5 +170,11 @@
         "reqJSONFile": "update-digital-individual-fulfillment.json",
         "resJSONFile": "on-update-digital-individual-fulfillment.json",
         "exclude": ["body.context.timestamp"]
+    },
+    {
+        "queryName": "update-address",
+        "reqJSONFile": "update-address.json",
+        "resJSONFile": "on-update-address.json",
+        "exclude": ["body.context.timestamp"]
     }
 ]

--- a/packages/beckn-vendure-plugin/transformations/actions-1-1-0/on-status-beckn-response.jsonata
+++ b/packages/beckn-vendure-plugin/transformations/actions-1-1-0/on-status-beckn-response.jsonata
@@ -28,6 +28,7 @@
                         "area_code": $shippingAddress.postalCode
                     } : {},
                     "contact":{
+                        "name": $shippingAddress.fullName ? $shippingAddress.fullName : $customer.firstName & ' ' & $customer.lastName,
                         "phone": $shippingAddress.phoneNumber ? $shippingAddress.phoneNumber : $customer.phoneNumber,
                         "email": $customer.emailAddress
                     }


### PR DESCRIPTION
Currently the fulfillment object, stop field has delivery address. However the contact details there has only phone number and email. Add the name of the person who will pick up the order. This is very visible when we try to change the delivery address through update.